### PR TITLE
feat/#09/splash_screen

### DIFF
--- a/app/src/main/java/com/example/plango/LoginActivity.kt
+++ b/app/src/main/java/com/example/plango/LoginActivity.kt
@@ -1,19 +1,28 @@
 package com.example.plango
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.annotation.RequiresApi
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.example.plango.databinding.ActivityLoginBinding
 
 class LoginActivity : ComponentActivity() {
 
     private lateinit var binding: ActivityLoginBinding
 
+    @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreate(savedInstanceState: Bundle?) {
+
+        // 🔥 반드시 super.onCreate() 전에 실행해야 Splash가 뜨고 유지됨!
+        val splashScreen = installSplashScreen()
+
         super.onCreate(savedInstanceState)
+
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -39,11 +39,12 @@
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 
-    <style name="Theme.PlanGo.Splash" parent="Base.Theme.PlanGo">
+    <style name="Theme.PlanGo.Splash" parent="Theme.SplashScreen">
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_logo</item>
         <item name="windowSplashScreenBackground">@color/white</item>
         <item name="postSplashScreenTheme">@style/Theme.PlanGo</item>
     </style>
+
 
 </resources>
 


### PR DESCRIPTION
# 📌 Pull Request Title
feat: SplashScreen 적용 및 자연스러운 로딩 애니메이션 구현 (#09)

---

# ✨ 작업 내용 (What)
- Android SplashScreen API 적용
- 스플래쉬 화면 최소 노출시간(0.8초) 추가
- 스플래쉬 종료 시 페이드아웃(0.3초) 애니메이션 적용
- 앱 시작 시 PlanGo 로고가 자연스럽게 표시되도록 개선
- MainActivity에 Splash 초기화 로직 및 애니메이션 처리 코드 추가

---

# 🧩 변경 사항 (Changes)
- MainActivity.kt
   - installSplashScreen() 적용 위치 수정(super 전에)
   - splash 유지시간(keepOnScreenCondition + Handler) 추가
   - fade-out 애니메이션(alpha(0f, duration 300ms)) 추가
- AndroidManifest.xml
   - MainActivity에 Theme.PlanGo.Splash 적용
- themes.xml
   - 스플래쉬 전용 테마(Theme.PlanGo.Splash) 신규 추가
   - 로고 및 배경 설정
- drawable/
   - 스플래쉬 로고 리소스 추가 (splash_logo)

---

# 📸 스크린샷 (UI 변경 시 필수)

---

# 🧪 테스트 방법 (How to Test)
1. 앱 실행
2. 스플래쉬 로고가 약 0.8초 표시되는지 확인
3. 로고가 0.3초 동안 서서히 사라지는지 확인
4. MainActivity(HomeFragment)가 부드럽게 나타나는지 확인
5. 라이트/다크모드에서 스플래쉬 테마 정상 적용되는지 테스트

---

# ✔ 체크리스트 (Checklist)
- [✔] 정상적으로 빌드됨
- [✔] Figma 디자인과 일치
- [✔] 불필요한 코드/주석 제거
- [✔] 브랜치 규칙 준수(feat/fix/design/refactor)
- [✔] 커밋 규칙 준수
- [✔] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #09
