### PR TITLE
Feat/#15/login api

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/plango/LoginActivity.kt
+++ b/app/src/main/java/com/example/plango/LoginActivity.kt
@@ -5,15 +5,33 @@ import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
+import android.view.View
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.example.plango.data.RetrofitClient
+import com.example.plango.data.login_api.AuthRepository
+import com.example.plango.data.login_api.AuthService
+import com.example.plango.data.login_api.AuthViewModel
+import com.example.plango.data.login_api.AuthViewModelFactory
+import com.example.plango.data.token.TokenManager
 import com.example.plango.databinding.ActivityLoginBinding
 
 class LoginActivity : ComponentActivity() {
 
     private lateinit var binding: ActivityLoginBinding
+
+    private val authService = RetrofitClient.authService
+    private val authRepository = AuthRepository(authService)
+
+    private val authViewModel: AuthViewModel by viewModels {
+        AuthViewModelFactory(authRepository)
+    }
+
+    private lateinit var tokenManager: TokenManager
 
     @RequiresApi(Build.VERSION_CODES.S)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,8 +44,22 @@ class LoginActivity : ComponentActivity() {
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        tokenManager = TokenManager(this)
+
+        // TODO: 프로필에서 로그아웃 기능 구현하고 활성화하기
+        // 🔥 자동 로그인
+//        val savedToken = tokenManager.getAccessToken()
+//        // TODO: 토큰 테스트 코드
+//        Log.d("TOKEN_TEST", "자동 로그인 체크 - 저장된 토큰 = $savedToken")
+//        if (!savedToken.isNullOrEmpty()) {
+//            startActivity(Intent(this, MainActivity::class.java))
+//            finish()
+//            return
+//        }
+
         setupTextWatchers()
         setupButtonListeners()
+        observeLogin()
     }
 
     /** ---------------------------
@@ -58,26 +90,45 @@ class LoginActivity : ComponentActivity() {
         binding.btnLogin.alpha = if (enabled) 1f else 0.5f
     }
 
+    // 로그인 결과 관찰
+    private fun observeLogin() {
+
+        authViewModel.loginResult.observe(this) { result ->
+
+            binding.tvError.visibility = View.GONE
+
+            result.onSuccess { data ->
+
+                tokenManager.saveAccessToken(data.accessToken)
+
+                // TODO : 로그인 토큰 테스트 코드
+                Log.d("TOKEN_TEST", "token = ${tokenManager.getAccessToken()}")
+
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            }
+
+            result.onFailure {
+                // 로그인 실패
+                binding.tvError.text = "로그인 실패: 아이디 또는 비밀번호를 확인하세요."
+                binding.tvError.visibility = View.VISIBLE
+            }
+        }
+    }
+
+
     /** ---------------------------
      *  버튼 클릭 리스너
      * -------------------------- */
-    private fun setupButtonListeners() {
+    private fun setupButtonListeners()  {
 
         /** LOGIN 버튼 */
         binding.btnLogin.setOnClickListener {
             val id = binding.etId.text.toString()
             val pw = binding.etPw.text.toString()
 
-            if (id == "test" && pw == "1234") {
-                binding.tvError.visibility = android.view.View.GONE
-                Toast.makeText(this, "로그인 성공!", Toast.LENGTH_SHORT).show()
-
-                val intent = Intent(this, MainActivity::class.java)
-                startActivity(intent)
-                finish()
-            } else {
-                binding.tvError.visibility = android.view.View.VISIBLE
-            }
+            // 일반 로그인 실행
+            authViewModel.loginNormal(id, pw)
         }
 
         /** 아이디 찾기 */

--- a/app/src/main/java/com/example/plango/LoginActivity.kt
+++ b/app/src/main/java/com/example/plango/LoginActivity.kt
@@ -47,7 +47,7 @@ class LoginActivity : ComponentActivity() {
         tokenManager = TokenManager(this)
 
         // TODO: 프로필에서 로그아웃 기능 구현하고 활성화하기
-        // 🔥 자동 로그인
+//        // 🔥 자동 로그인
 //        val savedToken = tokenManager.getAccessToken()
 //        // TODO: 토큰 테스트 코드
 //        Log.d("TOKEN_TEST", "자동 로그인 체크 - 저장된 토큰 = $savedToken")
@@ -100,9 +100,10 @@ class LoginActivity : ComponentActivity() {
             result.onSuccess { data ->
 
                 tokenManager.saveAccessToken(data.accessToken)
+//                tokenManager.saveRefreshToken(data.refreshToken)
 
-                // TODO : 로그인 토큰 테스트 코드
-                Log.d("TOKEN_TEST", "token = ${tokenManager.getAccessToken()}")
+                Log.d("TOKEN_TEST", "access = ${tokenManager.getAccessToken()}")
+                Log.d("TOKEN_TEST", "refresh = ${tokenManager.getRefreshToken()}")
 
                 startActivity(Intent(this, MainActivity::class.java))
                 finish()

--- a/app/src/main/java/com/example/plango/MyApplication.kt
+++ b/app/src/main/java/com/example/plango/MyApplication.kt
@@ -1,0 +1,13 @@
+package com.example.plango
+
+import android.app.Application
+import com.example.plango.data.RetrofitClient
+
+class MyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        // 앱 시작 시 1회 Retrofit 초기화
+        RetrofitClient.init(this)
+    }
+}

--- a/app/src/main/java/com/example/plango/data/RetrofitClient.kt
+++ b/app/src/main/java/com/example/plango/data/RetrofitClient.kt
@@ -1,5 +1,10 @@
 package com.example.plango.data
 
+import android.content.Context
+import com.example.plango.data.login_api.AuthService
+import com.example.plango.data.token.AuthInterceptor
+import com.example.plango.data.token.TokenManager
+import com.google.gson.GsonBuilder
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -11,8 +16,19 @@ object RetrofitClient {
     // 🔁 호스트(네 컴퓨터) 실제 IP + 포트내 ip : 210.119.237.48(진성, 172~~는주희)
     //private const val BASE_URL = "http://172.25.81.234:8080/"
 
-    private const val BASE_URL = " https://pyrological-nonsalutarily-hobert.ngrok-free.dev"
+    private lateinit var tokenManager: TokenManager
 
+    private const val BASE_URL = "https://pyrological-nonsalutarily-hobert.ngrok-free.dev"
+
+    // 앱 시작 시 1번만 초기화됨 (MyApplication에서 호출)
+    fun init(context: Context) {
+        tokenManager = TokenManager(context)
+    }
+
+    // Gson 설정 (null 허용 / lenient 모드)
+    private val gson = GsonBuilder()
+        .setLenient()
+        .create()
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY   // 요청/응답 전체 로그 확인용
@@ -20,7 +36,8 @@ object RetrofitClient {
 
     private val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
+            .addInterceptor(loggingInterceptor)                  // 로그 출력
+            .addInterceptor(AuthInterceptor(tokenManager))       // 🔥 토큰 자동 추가
             .build()
     }
 
@@ -30,6 +47,11 @@ object RetrofitClient {
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
+    }
+
+    // AuthService (로그인/회원가입 등)
+    val authService: AuthService by lazy {
+        retrofit.create(AuthService::class.java)
     }
 
     val roomApiService: RoomApiService by lazy {

--- a/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
@@ -1,0 +1,40 @@
+package com.example.plango.data.login_api
+
+import com.example.plango.model.login_api.LoginData
+import com.example.plango.model.login_api.LoginRequest
+
+class AuthRepository(private val service: AuthService) {
+
+    // 일반 로그인
+    suspend fun loginNormal(req: LoginRequest): Result<LoginData> = try {
+
+        val response = service.loginNormal(req)
+
+        if (response.isSuccessful) {
+            val body = response.body()
+
+            when {
+                body == null -> {
+                    // body 자체가 null일 때
+                    Result.failure(Exception("Response body is null"))
+                }
+                body.data == null -> {
+                    // data가 null일 때
+                    Result.failure(Exception(body.message))
+                }
+                else -> {
+                    // 로그인 성공
+                    Result.success(body.data)
+                }
+            }
+
+        } else {
+            // HTTP 오류
+            Result.failure(Exception("HTTP ${response.code()}"))
+        }
+
+    } catch (e: Exception) {
+        // 네트워크 오류
+        Result.failure(e)
+    }
+}

--- a/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
@@ -1,0 +1,15 @@
+package com.example.plango.data.login_api
+
+import com.example.plango.model.login_api.LoginRequest
+import com.example.plango.model.login_api.LoginResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+
+    @POST("/api/auth/login")  // 일반 로그인 API
+    suspend fun loginNormal(
+        @Body request: LoginRequest
+    ): Response<LoginResponse>
+}

--- a/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
@@ -1,0 +1,29 @@
+package com.example.plango.data.login_api
+
+import androidx.lifecycle.*
+import com.example.plango.model.login_api.LoginData
+import com.example.plango.model.login_api.LoginRequest
+import kotlinx.coroutines.launch
+
+class AuthViewModel(private val repository: AuthRepository) : ViewModel() {
+
+    private val _loginResult = MutableLiveData<Result<LoginData>>()
+    val loginResult: LiveData<Result<LoginData>> = _loginResult
+
+    // 일반 로그인 실행
+    fun loginNormal(loginId: String, password: String) {
+        viewModelScope.launch {
+            _loginResult.value = repository.loginNormal(
+                LoginRequest(loginId, password)
+            )
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+class AuthViewModelFactory(private val repository: AuthRepository) :
+    ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return AuthViewModel(repository) as T
+    }
+}

--- a/app/src/main/java/com/example/plango/data/token/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/plango/data/token/AuthInterceptor.kt
@@ -1,0 +1,23 @@
+package com.example.plango.data.token
+
+import android.util.Log
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AuthInterceptor(private val tokenManager: TokenManager) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+
+        val token = tokenManager.getAccessToken()
+
+        val newRequest = chain.request().newBuilder().apply {
+            if (!token.isNullOrEmpty()) {
+                // Authorization 헤더 자동 추가
+                addHeader("Authorization", "Bearer $token")
+                // TODO: 토큰 테스트 코드
+                Log.d("TOKEN_TEST", "요청에 자동 추가된 Authorization = Bearer $token")
+            }
+        }.build()
+
+        return chain.proceed(newRequest)
+    }
+}

--- a/app/src/main/java/com/example/plango/data/token/TokenManager.kt
+++ b/app/src/main/java/com/example/plango/data/token/TokenManager.kt
@@ -1,22 +1,45 @@
 package com.example.plango.data.token
 
 import android.content.Context
-import android.content.SharedPreferences
 
 class TokenManager(context: Context) {
 
-    private val prefs: SharedPreferences =
-        context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+    private val prefs = context.getSharedPreferences("token_prefs", Context.MODE_PRIVATE)
 
+    // 🔹 AccessToken 저장
     fun saveAccessToken(token: String) {
-        prefs.edit().putString("access_token", token).apply()
+        prefs.edit()
+            .putString("access_token", token)
+            .apply()
     }
 
-    fun getAccessToken(): String? {
-        return prefs.getString("access_token", null)
+    // 🔹 RefreshToken 저장
+    fun saveRefreshToken(token: String) {
+        prefs.edit()
+            .putString("refresh_token", token)
+            .apply()
     }
 
-    fun clearToken() {
-        prefs.edit().remove("access_token").apply()
+    // 한번에 두 토큰 저장하는 함수
+    fun saveTokens(accessToken: String, refreshToken: String) {
+        prefs.edit()
+            .putString("access_token", accessToken)
+            .putString("refresh_token", refreshToken)
+            .apply()
+    }
+
+    // 🔹 AccessToken 조회
+    fun getAccessToken(): String? =
+        prefs.getString("access_token", null)
+
+    // 🔹 RefreshToken 조회
+    fun getRefreshToken(): String? =
+        prefs.getString("refresh_token", null)
+
+    // 🔹 전체 삭제 (로그아웃 시)
+    fun clearTokens() {
+        prefs.edit()
+            .clear()
+            .apply()
     }
 }

--- a/app/src/main/java/com/example/plango/data/token/TokenManager.kt
+++ b/app/src/main/java/com/example/plango/data/token/TokenManager.kt
@@ -1,0 +1,22 @@
+package com.example.plango.data.token
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class TokenManager(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+
+    fun saveAccessToken(token: String) {
+        prefs.edit().putString("access_token", token).apply()
+    }
+
+    fun getAccessToken(): String? {
+        return prefs.getString("access_token", null)
+    }
+
+    fun clearToken() {
+        prefs.edit().remove("access_token").apply()
+    }
+}

--- a/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
@@ -1,0 +1,7 @@
+package com.example.plango.model.login_api
+
+// 로그인 요청 바디
+data class LoginRequest(
+    val loginId: String,   // 아이디
+    val password: String   // 비밀번호
+)

--- a/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
@@ -14,6 +14,6 @@ data class LoginData(
     val nickname: String,
     val profileImageUrl: String?,
     val newMember: Boolean,
-    val accessToken: String
-//    val refreshToken: String?     // 추가 가능
+    val accessToken: String,
+    val refreshToken: String?
 )

--- a/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
@@ -1,0 +1,19 @@
+package com.example.plango.model.login_api
+
+// API 응답 전체
+data class LoginResponse(
+    val code: String,        // 응답 코드
+    val message: String,    // 응답 메시지
+    val data: LoginData?     // 로그인 결과 정보
+)
+
+// 로그인 성공 시 data 내부 구조
+data class LoginData(
+    val memberId: Int,
+    val email: String,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val newMember: Boolean,
+    val accessToken: String
+//    val refreshToken: String?     // 추가 가능
+)


### PR DESCRIPTION
# 📌 Pull Request Title
feat: 로그인 API 연동 및 토큰 저장 기능 구현 

---

# ✨ 작업 내용 (What)
- 로그인 API(/api/auth/login) 연동
- 서버 응답 데이터(memberId, email, nickname 등) 모델 구성
- AccessToken / RefreshToken 저장 기능 구현 (TokenManager)
- API 요청에 AccessToken 자동 추가 (AuthInterceptor)
- RetrofitClient 구성 및 Interceptor 적용

---

# 🧩 변경 사항 (Changes)
1. 로그인 응답 모델 추가
- Swagger 기반 LoginResponse, LoginData 데이터 클래스 생성
- 응답 내 accessToken, refreshToken 필드 매핑

2. TokenManager 구현
- accessToken / refreshToken 저장, 조회, 삭제 기능 구현
- 로그인 성공 시 두 토큰을 함께 저장하도록 구성

3. AuthInterceptor 적용
- 모든 서버 요청에 Authorization 헤더 자동 추가
- 토큰이 없으면 헤더 제외

4. RefreshToken 기능 관련
- 현재 PR에서는 “토큰 자동 재발급 기능”을 구현하지 않음
- RefreshToken은 저장만 하고 실제 사용(재발급 호출)은 추후 구현 예정
- 백엔드에서 재발급 API가 제공되면 별도 브랜치에서 기능 확장할 계획

---

# 📸 스크린샷 (UI 변경 시 필수)

---

# 🧪 테스트 방법 (How to Test)
1. 로그인 화면에서 테스트 계정 입력 후 로그인
2. 성공 시 Logcat에서 응답 데이터 및 토큰 저장 여부 확인
3. SharedPreferences(token_prefs)에 accessToken/refreshToken 저장 확인
4. 이후 API 호출 시 Authorization 헤더 자동 포함 여부 확인

---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #15
