### PR TITLE
feat/#16/kakao_login_api_again

### DIFF
--- a/app/src/main/java/com/example/plango/KakaoNicknameActivity.kt
+++ b/app/src/main/java/com/example/plango/KakaoNicknameActivity.kt
@@ -1,0 +1,160 @@
+package com.example.plango
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.example.plango.data.MemberSession
+import com.example.plango.data.RetrofitClient
+import com.example.plango.data.login_api.AuthRepository
+import com.example.plango.data.login_api.AuthViewModel
+import com.example.plango.data.login_api.AuthViewModelFactory
+import com.example.plango.data.token.TokenManager
+import com.example.plango.databinding.ActivityKakaoNicknameBinding
+
+class KakaoNicknameActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityKakaoNicknameBinding
+
+    private val authService = RetrofitClient.authService
+    private val authRepository = AuthRepository(authService)
+    private val viewModel: AuthViewModel by viewModels {
+        AuthViewModelFactory(authRepository)
+    }
+
+    private lateinit var tokenManager: TokenManager
+
+    private var email: String? = null
+    private var profileImageUrl: String? = null
+
+    private var isNicknameValid = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityKakaoNicknameBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        tokenManager = TokenManager(this)
+
+        email = intent.getStringExtra("email")
+        profileImageUrl = intent.getStringExtra("profileImageUrl")
+
+        setupTextWatcher()
+        setupButtonListeners()
+        observeNicknameCheck()
+
+        // ❌ BE API 미완성 → 임시로 주석 처리
+        // observeKakaoSignup()
+    }
+
+    private fun setupTextWatcher() {
+        binding.signUpNicknameEt.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {
+                binding.tvNicknameStatus.text = ""
+                isNicknameValid = false
+                binding.btnSignup.alpha = 0.5f
+                binding.btnSignup.isEnabled = false
+            }
+
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        })
+    }
+
+    private fun setupButtonListeners() {
+
+        // 닉네임 중복확인
+        binding.btnNicknameCheck.setOnClickListener {
+            val nickname = binding.signUpNicknameEt.text.toString().trim()
+
+            if (nickname.isBlank()) {
+                Toast.makeText(this, "닉네임을 입력하세요.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            viewModel.checkNickname(nickname)
+        }
+
+        // 카카오 회원가입 완료 버튼 (현재 API 없음 → 임시 비활성)
+        binding.btnSignup.setOnClickListener {
+
+            if (!isNicknameValid) {
+                Toast.makeText(this, "닉네임 중복 확인을 해주세요.", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+
+            Toast.makeText(this, "BE API 준비 중입니다.", Toast.LENGTH_SHORT).show()
+
+            // ❌ BE API 없는 부분 임시 삭제
+            /*
+            val nickname = binding.signUpNicknameEt.text.toString().trim()
+
+            viewModel.signupKakao(
+                nickname = nickname,
+                email = email ?: "",
+                profileImageUrl = profileImageUrl
+            )
+            */
+        }
+    }
+
+    private fun observeNicknameCheck() {
+        viewModel.nicknameCheckState.observe(this) { result ->
+            result.onSuccess { available ->
+                if (available) {
+                    binding.tvNicknameStatus.setTextColor(Color.parseColor("#51BDEB"))
+                    binding.tvNicknameStatus.text = "사용 가능한 닉네임입니다."
+                    isNicknameValid = true
+
+                    binding.btnSignup.alpha = 1f
+                    binding.btnSignup.isEnabled = true
+
+                } else {
+                    binding.tvNicknameStatus.setTextColor(Color.parseColor("#FF4C4C"))
+                    binding.tvNicknameStatus.text = "이미 사용 중인 닉네임입니다."
+                    isNicknameValid = false
+
+                    binding.btnSignup.alpha = 0.5f
+                    binding.btnSignup.isEnabled = false
+                }
+            }
+
+            result.onFailure {
+                binding.tvNicknameStatus.setTextColor(Color.parseColor("#FF4C4C"))
+                binding.tvNicknameStatus.text = "닉네임 확인 실패"
+                isNicknameValid = false
+            }
+        }
+    }
+
+    // ❌ 아직 API 없음 → 임시 주석
+    /*
+    private fun observeKakaoSignup() {
+        viewModel.kakaoSignupState.observe(this) { result ->
+            result.onSuccess { data ->
+
+                tokenManager.saveAccessToken(data.accessToken)
+                tokenManager.saveRefreshToken(data.refreshToken)
+
+                MemberSession.currentMemberId = data.memberId.toLong()
+                MemberSession.email = data.email
+                MemberSession.nickname = data.nickname
+                MemberSession.profileImageUrl = data.profileImageUrl
+
+                Toast.makeText(this, "회원가입 완료!", Toast.LENGTH_SHORT).show()
+
+                startActivity(Intent(this, MainActivity::class.java))
+                finish()
+            }
+
+            result.onFailure {
+                Toast.makeText(this, "회원가입 실패: ${it.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+    */
+}

--- a/app/src/main/java/com/example/plango/LoginActivity.kt
+++ b/app/src/main/java/com/example/plango/LoginActivity.kt
@@ -19,6 +19,7 @@ import com.example.plango.data.login_api.AuthViewModel
 import com.example.plango.data.login_api.AuthViewModelFactory
 import com.example.plango.data.token.TokenManager
 import com.example.plango.databinding.ActivityLoginBinding
+import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.util.Utility
 import com.kakao.sdk.user.UserApiClient
 
@@ -133,29 +134,113 @@ class LoginActivity : ComponentActivity() {
         }
     }
 
+    // ------------------------------
+    //  카카오 로그인 진입 함수
+    // ------------------------------
+    private fun startKakaoLogin() {
+
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
+
+            UserApiClient.instance.loginWithKakaoTalk(this) { token, error ->
+                if (token != null) {
+                    sendKakaoTokenToServer(token)
+                } else {
+                    loginWithKakaoAccount()
+                }
+            }
+
+        } else {
+            loginWithKakaoAccount()
+        }
+    }
+
+    // ------------------------------
+    //  카카오 계정 로그인
+    // ------------------------------
+    private fun loginWithKakaoAccount() {
+
+        UserApiClient.instance.loginWithKakaoAccount(this) { token, error ->
+
+            if (error != null) {
+                Toast.makeText(this, "카카오 로그인 실패", Toast.LENGTH_SHORT).show()
+                return@loginWithKakaoAccount
+            }
+
+            if (token != null) {
+                sendKakaoTokenToServer(token)
+            }
+        }
+    }
+
+
+    // ------------------------------
+    //  카카오 토큰을 BE로 전달하는 핵심 함수
+    // ------------------------------
+    private fun sendKakaoTokenToServer(token: OAuthToken) {
+
+        val access = token.accessToken
+        val id = token.idToken ?: ""
+
+        Log.d("KAKAO_LOGIN", "accessToken: $access")
+        Log.d("KAKAO_LOGIN", "idToken: $id")
+
+        authViewModel.loginKakao(access, id)
+    }
 
     // ------------------------------
     //  카카오 로그인 결과 처리
     // ------------------------------
+    // TODO: 닉네임 저장 API 연동 후에는 지우고 아래 코드 써야함
     private fun observeKakaoLogin() {
-        authViewModel.kakaoLoginResult.observe(this) { result ->
-
+        authViewModel.kakaoLoginState.observe(this) { result ->
             result.onSuccess { data ->
+
+                // 토큰 저장
                 tokenManager.saveAccessToken(data.accessToken)
                 tokenManager.saveRefreshToken(data.refreshToken)
 
-                Toast.makeText(this, "카카오 로그인 성공!", Toast.LENGTH_SHORT).show()
-
-                startActivity(Intent(this, MainActivity::class.java))
-                finish()
+                if (data.newMember) {
+                    // 신규 회원 → 닉네임 설정으로 이동
+                    val intent = Intent(this, KakaoNicknameActivity::class.java)
+                    intent.putExtra("email", data.email)
+                    intent.putExtra("profileImageUrl", data.profileImageUrl)
+                    startActivity(intent)
+                    finish()
+                } else {
+                    // 기존 회원 → 바로 메인
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }
             }
 
-            result.onFailure { error ->
-                Log.e("KAKAO_LOGIN_ERROR", "카카오 로그인 실패", error)
-                Toast.makeText(this, "카카오 로그인 실패: ${error.message}", Toast.LENGTH_SHORT).show()
+            result.onFailure {
+                Toast.makeText(this, "카카오 로그인 실패", Toast.LENGTH_SHORT).show()
             }
         }
     }
+
+//    private fun observeKakaoLogin() {
+//        authViewModel.kakaoLoginResult.observe(this) { result ->
+//            result.onSuccess { data ->
+//
+//                tokenManager.saveAccessToken(data.accessToken)
+//                tokenManager.saveRefreshToken(data.refreshToken)
+//
+//                if (data.newMember) {
+//                    // 닉네임 설정 화면으로 이동
+//                    val intent = Intent(this, KakaoNicknameActivity::class.java)
+//                    intent.putExtra("email", data.email)
+//                    intent.putExtra("profileImageUrl", data.profileImageUrl)
+//                    startActivity(intent)
+//                    finish()
+//                } else {
+//                    // 기존 회원 → 바로 메인 이동
+//                    startActivity(Intent(this, MainActivity::class.java))
+//                    finish()
+//                }
+//            }
+//        }
+//    }
 
 
     // ------------------------------
@@ -188,51 +273,5 @@ class LoginActivity : ComponentActivity() {
         binding.tvFindPw.setOnClickListener {
             Toast.makeText(this, "비밀번호 찾기 화면으로 이동", Toast.LENGTH_SHORT).show()
         }
-    }
-
-
-    // ------------------------------
-    //  카카오 로그인 (카톡 앱 > 카카오 계정 로그인 선택)
-    // ------------------------------
-    private fun startKakaoLogin() {
-
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
-            // 카카오톡 앱 로그인
-            UserApiClient.instance.loginWithKakaoTalk(this) { token, error ->
-                if (token != null) {
-                    handleKakaoAuthorizationCode(token.accessToken)
-                } else {
-                    // 실패 시 계정 로그인으로 재시도
-                    loginWithKakaoAccount()
-                }
-            }
-        } else {
-            loginWithKakaoAccount()
-        }
-    }
-
-    // 카카오 계정 로그인
-    private fun loginWithKakaoAccount() {
-
-        UserApiClient.instance.loginWithKakaoAccount(this) { token, error ->
-            if (error != null) {
-                Toast.makeText(this, "카카오 로그인 실패", Toast.LENGTH_SHORT).show()
-                return@loginWithKakaoAccount
-            }
-
-            if (token != null) {
-                val authorizationCode = token.idToken ?: token.accessToken
-
-                Log.d("KAKAO_LOGIN", "authorizationCode = $authorizationCode")
-
-                authViewModel.loginKakao(authorizationCode)
-            }
-        }
-    }
-
-    // 카카오 accessToken → BE에 전달(= 명세서의 authorizationCode 역할)
-    private fun handleKakaoAuthorizationCode(authorizationCode: String) {
-        Log.d("KAKAO_LOGIN", "authorizationCode = $authorizationCode")
-        authViewModel.loginKakao(authorizationCode)
     }
 }

--- a/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
@@ -1,15 +1,17 @@
 package com.example.plango.data.login_api
 
-import com.example.plango.model.login_api.KakaoLoginRequest
-import com.example.plango.model.login_api.LoginData
-import com.example.plango.model.login_api.LoginRequest
-import com.example.plango.model.login_api.RefreshTokenRequest
+import com.example.plango.model.login_api.*
+import retrofit2.Response
 
 class AuthRepository(
     private val service: AuthService
 ) {
 
-    // 일반 로그인
+    /**
+     * ------------------------------------
+     * 🔐 일반 로그인
+     * ------------------------------------
+     */
     suspend fun loginNormal(req: LoginRequest): Result<LoginData> = try {
         val response = service.loginNormal(req)
 
@@ -21,6 +23,7 @@ class AuthRepository(
                 body.data == null -> Result.failure(Exception(body.message))
                 else -> Result.success(body.data)
             }
+
         } else {
             Result.failure(Exception("HTTP ${response.code()}"))
         }
@@ -30,11 +33,16 @@ class AuthRepository(
     }
 
 
-    // 카카오 로그인
-    suspend fun loginKakao(authorizationCode: String): Result<LoginData> = try {
+    /**
+     * ------------------------------------
+     * 🟡 카카오 로그인
+     * ------------------------------------
+     * Response<KakaoLoginResponse> 를 그대로 ViewModel로 넘기지 않고
+     * 여기서 data만 추출해주는 방식으로 통일하는 것이 중요!
+     */
+    suspend fun loginKakao(request: KakaoLoginRequest): Result<KakaoLoginData> = try {
 
-        val req = KakaoLoginRequest(authorizationCode)
-        val response = service.loginKakao(req)
+        val response = service.loginKakao(request)
 
         if (response.isSuccessful) {
             val body = response.body()
@@ -44,6 +52,7 @@ class AuthRepository(
                 body.data == null -> Result.failure(Exception(body.message))
                 else -> Result.success(body.data)
             }
+
         } else {
             Result.failure(Exception("HTTP ${response.code()}"))
         }
@@ -52,8 +61,11 @@ class AuthRepository(
         Result.failure(e)
     }
 
-
-    // 토큰 재발급
+    /**
+     * ------------------------------------
+     * 🔄 토큰 재발급 (추후 기능)
+     * ------------------------------------
+     */
 //    suspend fun refreshToken(refreshToken: String): Result<LoginData> = try {
 //
 //        val request = RefreshTokenRequest(refreshToken)
@@ -75,4 +87,23 @@ class AuthRepository(
 //    } catch (e: Exception) {
 //        Result.failure(e)
 //    }
+
+    // 닉네임 중복 확인 API
+    suspend fun checkNickname(nickname: String): Result<Boolean> = try {
+        val response = service.checkNickname(nickname)
+
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                Result.success(body.data.available)   // 여기!
+            } else {
+                Result.failure(Exception("Response body is null"))
+            }
+        } else {
+            Result.failure(Exception("HTTP ${response.code()}"))
+        }
+
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
 }

--- a/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
@@ -2,7 +2,8 @@ package com.example.plango.data.login_api
 
 import com.example.plango.model.login_api.KakaoLoginRequest
 import com.example.plango.model.ApiResponse
-import com.example.plango.model.NicknameCheckResponse
+import com.example.plango.model.login_api.NicknameCheckResponse
+import com.example.plango.model.login_api.KakaoLoginResponse
 import com.example.plango.model.login_api.LoginRequest
 import com.example.plango.model.login_api.LoginResponse
 import com.example.plango.model.login_api.RefreshTokenRequest
@@ -25,14 +26,13 @@ interface AuthService {
     @POST("/api/auth/login/kakao")
     suspend fun loginKakao(
         @Body request: KakaoLoginRequest
-    ): Response<LoginResponse>
+    ): Response<KakaoLoginResponse>
 
     // 토큰 재발급 API
     @POST("/api/auth/token/reissue")
     suspend fun reissueToken(
         @Body request: RefreshTokenRequest
     ): Response<RefreshTokenResponse>
-
 
     // 🔹 닉네임 중복확인
     @GET("/api/auth/check/nickname")

--- a/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
@@ -1,24 +1,35 @@
 package com.example.plango.data.login_api
 
 import androidx.lifecycle.*
-import com.example.plango.model.login_api.LoginData
-import com.example.plango.model.login_api.LoginRequest
+import com.example.plango.model.login_api.*
 import kotlinx.coroutines.launch
 
 class AuthViewModel(
     private val repository: AuthRepository
 ) : ViewModel() {
 
+    // ⚫ 일반 로그인 결과
     private val _normalLoginResult = MutableLiveData<Result<LoginData>>()
     val normalLoginResult: LiveData<Result<LoginData>> = _normalLoginResult
 
-    private val _kakaoLoginResult = MutableLiveData<Result<LoginData>>()
-    val kakaoLoginResult: LiveData<Result<LoginData>> = _kakaoLoginResult
+    // 🟡 카카오 로그인 결과
+    private val _kakaoLoginState = MutableLiveData<Result<KakaoLoginData>>()
+    val kakaoLoginState: LiveData<Result<KakaoLoginData>> get() = _kakaoLoginState
 
+    // 🔵 (추후용) 토큰 재발급
     private val _tokenRefreshResult = MutableLiveData<Result<LoginData>>()
     val tokenRefreshResult: LiveData<Result<LoginData>> = _tokenRefreshResult
 
+    // 닉네임 중복 확인
+    private val _nicknameCheckState = MutableLiveData<Result<Boolean>>()
+    val nicknameCheckState: LiveData<Result<Boolean>> = _nicknameCheckState
 
+
+    /**
+     * ------------------------
+     * 🔐 일반 로그인
+     * ------------------------
+     */
     fun loginNormal(email: String, password: String) {
         viewModelScope.launch {
             _normalLoginResult.value = repository.loginNormal(
@@ -27,15 +38,43 @@ class AuthViewModel(
         }
     }
 
-    fun loginKakao(authorizationCode: String) {
+
+    /**
+     * ------------------------
+     * 🟡 카카오 로그인
+     * ------------------------
+     *
+     * repository.loginKakao() 의 반환 타입:
+     * → Response<KakaoLoginResponse>
+     *
+     * KakaoLoginResponse.data 가 실제 유저 정보
+     */
+    fun loginKakao(accessToken: String, idToken: String) {
         viewModelScope.launch {
-            _kakaoLoginResult.value = repository.loginKakao(authorizationCode)
+            val request = KakaoLoginRequest(accessToken, idToken)
+
+            // Repository에서 이미 Result<KakaoLoginData> 형태로 준다!
+            val result = repository.loginKakao(request)
+
+            _kakaoLoginState.value = result
         }
     }
 
+
+    /**
+     * ------------------------
+     * 🔄 토큰 재발급 (추후 기능)
+     * ------------------------
+     */
 //    fun refreshToken(refreshToken: String) {
 //        viewModelScope.launch {
 //            _tokenRefreshResult.value = repository.refreshToken(refreshToken)
 //        }
 //    }
+
+    fun checkNickname(nickname: String) {
+        viewModelScope.launch {
+            _nicknameCheckState.value = repository.checkNickname(nickname)
+        }
+    }
 }

--- a/app/src/main/java/com/example/plango/model/NicknameCheckData.kt
+++ b/app/src/main/java/com/example/plango/model/NicknameCheckData.kt
@@ -1,8 +1,0 @@
-package com.example.plango.model
-
-
-data class NicknameCheckData(
-    val available: Boolean,
-    val field: String?,
-    val value: String?
-)

--- a/app/src/main/java/com/example/plango/model/NicknameCheckResponse.kt
+++ b/app/src/main/java/com/example/plango/model/NicknameCheckResponse.kt
@@ -1,7 +1,0 @@
-package com.example.plango.model
-
-data class NicknameCheckResponse(
-    val code: Int,
-    val message: String,
-    val data: NicknameCheckData?
-)

--- a/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
@@ -7,5 +7,6 @@ data class LoginRequest(
 )
 
 data class KakaoLoginRequest(
-    val authorizationCode: String
+    val accessToken: String,
+    val idToken: String
 )

--- a/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginResponse.kt
@@ -17,3 +17,19 @@ data class LoginData(
     val accessToken: String,
     val refreshToken: String
 )
+
+data class KakaoLoginResponse(
+    val code: Int,
+    val message: String,
+    val data: KakaoLoginData
+)
+
+data class KakaoLoginData(
+    val memberId: Int,
+    val email: String,
+    val nickname: String,
+    val profileImageUrl: String,
+    val newMember: Boolean,
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/app/src/main/java/com/example/plango/model/login_api/NicknameCheckResponse.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/NicknameCheckResponse.kt
@@ -1,0 +1,13 @@
+package com.example.plango.model.login_api
+
+data class NicknameCheckResponse(
+    val code: Int,
+    val message: String,
+    val data: NicknameCheckData
+)
+
+data class NicknameCheckData(
+    val available: Boolean,
+    val field: String,
+    val value: String
+)

--- a/app/src/main/res/layout/activity_kakao_nickname.xml
+++ b/app/src/main/res/layout/activity_kakao_nickname.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/main_logo_2">
+
+    <!-- 상단 헤더 (뒤로가기 + 로고) -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/signup_header"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:paddingTop="20dp"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <LinearLayout
+            android:id="@+id/btn_back"
+            android:layout_width="wrap_content"
+            android:layout_height="32dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:padding="4dp"
+            android:layout_marginStart="10dp"
+            android:background="@android:color/transparent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_back"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:src="@drawable/icon_back_room_making" />
+
+            <TextView
+                android:id="@+id/tv_back_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="뒤로"
+                android:textColor="#51BDEB"
+                android:textSize="14sp"
+                android:layout_marginStart="4dp" />
+        </LinearLayout>
+
+        <!-- 로고 -->
+        <ImageView
+            android:id="@+id/sign_up_logo_iv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/main_logo"
+            android:adjustViewBounds="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 제목 영역 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/signup_inner_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="32dp"
+        android:paddingTop="20dp"
+        android:paddingBottom="10dp"
+        app:layout_constraintTop_toBottomOf="@id/signup_header">
+
+        <TextView
+            android:id="@+id/sign_up_title_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="환영합니다!"
+            android:textSize="27sp"
+            android:textStyle="bold"
+            android:textAlignment="center"
+            android:textColor="#333333"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/sign_up_title_2_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="PlanGo, 지금 바로 시작해보세요."
+            android:textSize="14sp"
+            android:textAlignment="center"
+            android:textColor="#333333"
+            android:layout_marginTop="5dp"
+            app:layout_constraintTop_toBottomOf="@id/sign_up_title_tv"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 닉네임 입력 ScrollView -->
+    <ScrollView
+        android:id="@+id/signup_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@id/signup_inner_title"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/signup_inner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="32dp"
+            android:paddingBottom="40dp"
+            android:paddingTop="150dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+        <!-- 닉네임 라벨 -->
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/nickname_row"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <TextView
+                    android:id="@+id/label_nickname"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="닉네임"
+                    android:textColor="#333333"
+                    android:textSize="12sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"/>
+
+                <TextView
+                    android:id="@+id/sign_up_nickname_error_tv"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:textSize="11sp"
+                    android:textColor="#FF4C4C"
+                    android:visibility="gone"
+                    app:layout_constraintStart_toEndOf="@id/label_nickname"
+                    app:layout_constraintTop_toTopOf="@id/label_nickname" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+            <!-- 닉네임 입력창 -->
+            <EditText
+                android:id="@+id/sign_up_nickname_et"
+                android:layout_width="0dp"
+                android:layout_height="40dp"
+                android:background="@drawable/bg_signup_button"
+                android:hint="닉네임"
+                android:textSize="13sp"
+                android:paddingHorizontal="10dp"
+                android:layout_marginTop="4dp"
+                android:layout_marginEnd="4dp"
+                app:layout_constraintTop_toBottomOf="@id/nickname_row"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/btn_nickname_check" />
+
+            <!-- 중복확인 버튼 -->
+            <Button
+                android:id="@+id/btn_nickname_check"
+                android:layout_width="95dp"
+                android:layout_height="40dp"
+                android:text="중복 확인"
+                android:textSize="11sp"
+                android:textColor="#333333"
+                android:background="@drawable/bg_signup_check"
+                android:backgroundTint="@null"
+                app:backgroundTint="@null"
+                android:paddingVertical="6dp"
+                app:layout_constraintTop_toTopOf="@id/sign_up_nickname_et"
+                app:layout_constraintBottom_toBottomOf="@id/sign_up_nickname_et"
+                app:layout_constraintEnd_toEndOf="parent"/>
+
+            <!-- 닉네임 상태 메시지 -->
+            <TextView
+                android:id="@+id/tvNicknameStatus"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textSize="11sp"
+                android:layout_marginTop="6dp"
+                app:layout_constraintTop_toBottomOf="@id/sign_up_nickname_et"
+                app:layout_constraintStart_toStartOf="@id/sign_up_nickname_et"
+                app:layout_constraintEnd_toEndOf="@id/sign_up_nickname_et"/>
+
+
+            <!-- SIGN UP 버튼 -->
+            <Button
+                android:id="@+id/btnSignup"
+                android:layout_width="0dp"
+                android:layout_height="44dp"
+                android:text="SIGN UP"
+                android:background="@drawable/bg_login_button"
+                android:alpha="0.5"
+                android:textAllCaps="true"
+                android:textColor="#000000"
+                android:textSize="20sp"
+                android:backgroundTint="@null"
+                app:backgroundTint="@null"
+                app:layout_constraintTop_toBottomOf="@id/tvNicknameStatus"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:layout_marginTop="70dp"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
feat/#16/kakao_login_api_again

# 📌 Pull Request Title
feat: 카카오 로그인 로직 개선 및 신규회원 분기 처리 

---

# ✨ 작업 내용 (What)

- 카카오 로그인 로직 전체 리팩토링
- 기존 회원(newMember = false) 로그인 시 → 바로 MainActivity로 이동
- 신규 회원(newMember = true) 로그인 시 → 닉네임 설정 화면(KakaoNicknameActivity)로 이동하도록 분기 처리
- LoginActivity의 카카오 로그인 코드 구조 정리
- KakaoNicknameActivity와 연결되는 Intent 데이터(email, profileImageUrl) 전달 처리
- BE API 개발 전까지 signup 관련 부분은 주석 처리하여 컴파일 오류 제거

---

# 🧩 변경 사항 (Changes)
🔹 LoginActivity.kt
   - observeKakaoLogin() 로직 복구 및 데이터 구조에 맞게 수정
   - 카카오 로그인 성공 시 newMember 값에 따라 화면 분기 추가
   - sendKakaoTokenToServer() → loginKakao() 직접 호출하도록 유지
   - 컴파일 오류 제거 및 불필요한 구 코드는 주석 정리

🔹 KakaoNicknameActivity.kt
   - BE 가입 API 미구현 상태로 인해 오류 나던 signupKakao() 호출 부분 주석 처리
   - 닉네임 중복확인 기능 유지
   - BE API 완성 전까지 "준비 중입니다" 메시지 출력하도록 임시 처리

---

# 📸 스크린샷 (UI 변경 시 필수)

---

# 🧪 테스트 방법 (How to Test)

1. 카카오 로그인 버튼 클릭
2. 카카오 계정 선택 후 로그인 진행
3. BE 응답 newMember 값에 따라:
   - newMember = false → MainActivity로 이동되는지 확인
   - newMember = true → KakaoNicknameActivity로 이동되는지 확인
4. 닉네임 입력 후 중복 확인 버튼이 정상적으로 동작하는지 확인
5. signup 버튼 클릭 시 “BE API 준비 중” 메시지 출력되는지 확인

---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #33 
