### PR TITLE
feat/#32/id+email_check_api

### DIFF
--- a/app/src/main/java/com/example/plango/KakaoNicknameActivity.kt
+++ b/app/src/main/java/com/example/plango/KakaoNicknameActivity.kt
@@ -1,6 +1,5 @@
 package com.example.plango
 
-import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Editable
@@ -8,11 +7,11 @@ import android.text.TextWatcher
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import com.example.plango.data.MemberSession
 import com.example.plango.data.RetrofitClient
 import com.example.plango.data.login_api.AuthRepository
-import com.example.plango.data.login_api.AuthViewModel
-import com.example.plango.data.login_api.AuthViewModelFactory
+import com.example.plango.data.signup_api.SignupRepository
+import com.example.plango.data.signup_api.SignupViewModel
+import com.example.plango.data.signup_api.SignupViewModelFactory
 import com.example.plango.data.token.TokenManager
 import com.example.plango.databinding.ActivityKakaoNicknameBinding
 
@@ -22,8 +21,8 @@ class KakaoNicknameActivity : AppCompatActivity() {
 
     private val authService = RetrofitClient.authService
     private val authRepository = AuthRepository(authService)
-    private val viewModel: AuthViewModel by viewModels {
-        AuthViewModelFactory(authRepository)
+    private val viewModel: SignupViewModel by viewModels {
+        SignupViewModelFactory(SignupRepository(RetrofitClient.signupApiService))
     }
 
     private lateinit var tokenManager: TokenManager

--- a/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
@@ -87,23 +87,4 @@ class AuthRepository(
 //    } catch (e: Exception) {
 //        Result.failure(e)
 //    }
-
-    // 닉네임 중복 확인 API
-    suspend fun checkNickname(nickname: String): Result<Boolean> = try {
-        val response = service.checkNickname(nickname)
-
-        if (response.isSuccessful) {
-            val body = response.body()
-            if (body != null) {
-                Result.success(body.data.available)   // 여기!
-            } else {
-                Result.failure(Exception("Response body is null"))
-            }
-        } else {
-            Result.failure(Exception("HTTP ${response.code()}"))
-        }
-
-    } catch (e: Exception) {
-        Result.failure(e)
-    }
 }

--- a/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthService.kt
@@ -2,7 +2,7 @@ package com.example.plango.data.login_api
 
 import com.example.plango.model.login_api.KakaoLoginRequest
 import com.example.plango.model.ApiResponse
-import com.example.plango.model.login_api.NicknameCheckResponse
+import com.example.plango.model.signup_api.NicknameCheckResponse
 import com.example.plango.model.login_api.KakaoLoginResponse
 import com.example.plango.model.login_api.LoginRequest
 import com.example.plango.model.login_api.LoginResponse
@@ -33,12 +33,6 @@ interface AuthService {
     suspend fun reissueToken(
         @Body request: RefreshTokenRequest
     ): Response<RefreshTokenResponse>
-
-    // 🔹 닉네임 중복확인
-    @GET("/api/auth/check/nickname")
-    suspend fun checkNickname(
-        @Query("nickname") nickname: String
-    ): Response<NicknameCheckResponse>
 
     // ✅ 로그아웃
     @POST("/api/auth/logout")

--- a/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthViewModel.kt
@@ -19,15 +19,10 @@ class AuthViewModel(
     // 🔵 (추후용) 토큰 재발급
     private val _tokenRefreshResult = MutableLiveData<Result<LoginData>>()
     val tokenRefreshResult: LiveData<Result<LoginData>> = _tokenRefreshResult
-
-    // 닉네임 중복 확인
-    private val _nicknameCheckState = MutableLiveData<Result<Boolean>>()
-    val nicknameCheckState: LiveData<Result<Boolean>> = _nicknameCheckState
   
-    // 로딩 면화면
+    // 로딩 화면
     private val _loading = MutableLiveData<Boolean>()
     val loading: LiveData<Boolean> get() = _loading
-
 
 
     /**
@@ -85,10 +80,4 @@ class AuthViewModel(
 //            _tokenRefreshResult.value = repository.refreshToken(refreshToken)
 //        }
 //    }
-
-    fun checkNickname(nickname: String) {
-        viewModelScope.launch {
-            _nicknameCheckState.value = repository.checkNickname(nickname)
-        }
-    }
 }

--- a/app/src/main/java/com/example/plango/data/signup_api/SignupRepository.kt
+++ b/app/src/main/java/com/example/plango/data/signup_api/SignupRepository.kt
@@ -4,9 +4,65 @@ import com.example.plango.model.signup_api.SignupRequest
 import com.example.plango.model.signup_api.SignupResponse
 import retrofit2.Response
 
-class SignupRepository(private val signupService: SignupService) {
+class SignupRepository(private val service: SignupService) {
 
+    // 회원가입
     suspend fun signup(request: SignupRequest): Response<SignupResponse> {
-        return signupService.signup(request)
+        return service.signup(request)
+    }
+
+    // 닉네임 중복 확인
+    suspend fun checkNickname(nickname: String): Result<Boolean> = try {
+        val response = service.checkNickname(nickname)
+
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                Result.success(body.data.available)
+            } else {
+                Result.failure(Exception("Response body is null"))
+            }
+        } else {
+            Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    // 아이디 중복 확인
+    suspend fun checkLoginId(loginId: String): Result<Boolean> = try {
+        val response = service.checkLoginId(loginId)
+
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                Result.success(body.data.available)
+            } else {
+                Result.failure(Exception("Response body is null"))
+            }
+        } else {
+            Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+
+    // 이메일 중복 확인
+    suspend fun checkEmail(email: String): Result<Boolean> = try {
+        val response = service.checkEmail(email)
+
+        if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                Result.success(body.data.available)
+            } else {
+                Result.failure(Exception("Response body is null"))
+            }
+        } else {
+            Result.failure(Exception("HTTP ${response.code()}"))
+        }
+    } catch (e: Exception) {
+        Result.failure(e)
     }
 }

--- a/app/src/main/java/com/example/plango/data/signup_api/SignupService.kt
+++ b/app/src/main/java/com/example/plango/data/signup_api/SignupService.kt
@@ -1,15 +1,37 @@
 package com.example.plango.data.signup_api
 
+import com.example.plango.model.signup_api.NicknameCheckResponse
 import com.example.plango.model.signup_api.SignupRequest
 import com.example.plango.model.signup_api.SignupResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface SignupService {
 
+    // 회원가입
     @POST("/api/auth/signup")
     suspend fun signup(
         @Body request: SignupRequest
     ): Response<SignupResponse>
+
+    // 닉네임 중복확인
+    @GET("/api/auth/check/nickname")
+    suspend fun checkNickname(
+        @Query("nickname") nickname: String
+    ): Response<NicknameCheckResponse>
+
+    // id 중복 확인
+    @GET("/api/auth/check/login-id")
+    suspend fun checkLoginId(
+        @Query("loginId") loginId: String
+    ): Response<NicknameCheckResponse>   // 동일 구조 재사용
+
+    // email 중복 확인
+    @GET("/api/auth/check/email")
+    suspend fun checkEmail(
+        @Query("email") email: String
+    ): Response<NicknameCheckResponse>
 }

--- a/app/src/main/java/com/example/plango/data/signup_api/SignupViewModel.kt
+++ b/app/src/main/java/com/example/plango/data/signup_api/SignupViewModel.kt
@@ -17,6 +17,18 @@ class SignupViewModel(private val repository: SignupRepository) : ViewModel() {
     private val _loading = MutableLiveData<Boolean>()
     val loading: LiveData<Boolean> get() = _loading
 
+    // 닉네임 중복 확인
+    private val _nicknameCheckState = MutableLiveData<Result<Boolean>>()
+    val nicknameCheckState: LiveData<Result<Boolean>> = _nicknameCheckState
+
+    // id 중복 확인
+    private val _loginIdCheckState = MutableLiveData<Result<Boolean>>()
+    val loginIdCheckState: LiveData<Result<Boolean>> = _loginIdCheckState
+
+    // email 중복 확인
+    private val _emailCheckState = MutableLiveData<Result<Boolean>>()
+    val emailCheckState: LiveData<Result<Boolean>> = _emailCheckState
+
 
     fun signup(name: String, nickname: String, loginId: String, password: String, email: String) {
         viewModelScope.launch {
@@ -42,6 +54,27 @@ class SignupViewModel(private val repository: SignupRepository) : ViewModel() {
             } finally {
                 _loading.value = false  // 🔥 로딩 끝
             }
+        }
+    }
+
+    // 닉네임 중복 확인
+    fun checkNickname(nickname: String) {
+        viewModelScope.launch {
+            _nicknameCheckState.value = repository.checkNickname(nickname)
+        }
+    }
+
+    // id 중복 확인
+    fun checkLoginId(loginId: String) {
+        viewModelScope.launch {
+            _loginIdCheckState.value = repository.checkLoginId(loginId)
+        }
+    }
+
+    // email 중복 확인
+    fun checkEmail(email: String) {
+        viewModelScope.launch {
+            _emailCheckState.value = repository.checkEmail(email)
         }
     }
 }

--- a/app/src/main/java/com/example/plango/model/signup_api/NicknameCheckResponse.kt
+++ b/app/src/main/java/com/example/plango/model/signup_api/NicknameCheckResponse.kt
@@ -1,4 +1,4 @@
-package com.example.plango.model.login_api
+package com.example.plango.model.signup_api
 
 data class NicknameCheckResponse(
     val code: Int,


### PR DESCRIPTION
feat/#32/id+email_check_api

# 📌 Pull Request Title
feat: 회원가입 중복확인 기능(id/email/nickname) 및 닉네임 수정 다이얼로그 API 연동

---

# ✨ 작업 내용 (What)
🔹 회원가입(SignUpActivity)
- 아이디(ID) 중복확인 API 연동
- 이메일 중복확인 API 연동
- 닉네임 중복확인 API 연동
- 중복확인 결과에 따라 버튼 활성화/비활성 처리
- ViewModel(SignupViewModel) 구조 개선 후 observe 처리

🔹 닉네임 수정(NicknameEditDialogFragment)
- 닉네임 중복확인 API(SignupViewModel.checkNickname) 연동
- lateinit crash 해결 (정상 viewModel 주입)
- 라이프사이클 오류 해결 (observe(this) 적용)
- 닉네임 변경 API 성공 시 MemberSession 즉시 갱신

🔹 카카오 첫 가입 닉네임 화면(KakaoNicknameActivity)
- 닉네임 중복확인 로직 SignupViewModel 기반으로 통합
- 기존 AuthViewModel 사용 부분 정리

🔹 SignupRepository
- checkNickname, checkLoginId, checkEmail API 로직 정리
- 모든 중복확인 API를 Result<Boolean> 형태로 통일

---

# 🧩 변경 사항 (Changes)
1. SignUpActivity.kt
   - observeDuplicateChecks() 추가
   - btnIdCheck / btnEmailCheck / btnNicknameCheck 모두 API 연동
   - 유효성 + 중복확인 플래그(isIdChecked, isEmailChecked, isNicknameChecked) 반영
2. SignupViewModel.kt
3. SignupRepository.kt
4. NicknameEditDialogFragment.kt
   - signupViewModel 로직 정상 동작하도록 개선
   - 닉네임 중복확인 UI 반영
   - viewLifecycleOwner crash 해결 → observe(this)
   - 닉네임 변경 API 연동 & 화면 자동 갱신
5. KakaoNicknameActivity.kt
   - nicknameCheck 전부 signupViewModel로 통합
   - 저장 버튼 활성화 조건 개선

---

# 📸 스크린샷 (UI 변경 시 필수)

---

# 🧪 테스트 방법 (How to Test)
✔ 회원가입 화면

1. 아이디 입력 → "중복확인" 클릭
   - 사용 가능: 초록 메세지 출력
   - 중복: 빨간 메세지 출력
2. 이메일 입력 → 중복확인
3. 닉네임 입력 → 중복확인
4. 모든 조건 통과 시 “회원가입” 버튼 활성화
5. 회원가입 정상 호출되는지 확인

✔ 닉네임 수정 다이얼로그

1. 닉네임 수정 버튼 클릭
2. 새로운 닉네임 입력 → "중복확인"
3. 가능하면 저장 → 서버에서 프로필 갱신
4. MyPage 즉시 반영되는지 확인

✔ 카카오 닉네임 화면

1. 닉네임 입력 후 중복확인
2. 사용 가능해야 다음 진행 가능

---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #00 (있을 경우)
