### PR TITLE
feat/#16/kakao_login_api_again_2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <!-- 네이티브 앱 키로 스킴 설정 필수 -->
-                <data android:scheme="kakao565207f78fbd8da404f0288d6d5f9ebd" />
+                <data android:scheme="565207f78fbd8da404f0288d6d5f9ebd" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
+++ b/app/src/main/java/com/example/plango/data/login_api/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.example.plango.data.login_api
 
+import com.example.plango.data.RetrofitClient.authService
 import com.example.plango.model.login_api.*
 import retrofit2.Response
 
@@ -40,25 +41,8 @@ class AuthRepository(
      * Response<KakaoLoginResponse> 를 그대로 ViewModel로 넘기지 않고
      * 여기서 data만 추출해주는 방식으로 통일하는 것이 중요!
      */
-    suspend fun loginKakao(request: KakaoLoginRequest): Result<KakaoLoginData> = try {
-
-        val response = service.loginKakao(request)
-
-        if (response.isSuccessful) {
-            val body = response.body()
-
-            when {
-                body == null -> Result.failure(Exception("Response body is null"))
-                body.data == null -> Result.failure(Exception(body.message))
-                else -> Result.success(body.data)
-            }
-
-        } else {
-            Result.failure(Exception("HTTP ${response.code()}"))
-        }
-
-    } catch (e: Exception) {
-        Result.failure(e)
+    suspend fun loginKakao(request: KakaoLoginRequest): Response<KakaoLoginResponse> {
+        return authService.loginKakao(request)
     }
 
     /**

--- a/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
+++ b/app/src/main/java/com/example/plango/model/login_api/LoginRequest.kt
@@ -8,5 +8,5 @@ data class LoginRequest(
 
 data class KakaoLoginRequest(
     val accessToken: String,
-    val idToken: String
+    val idToken: String?
 )


### PR DESCRIPTION
feat/#16/kakao_login_api_again_2

# 📌 Pull Request Title
feat: 카카오 로그인 UI 및 SDK 연동 구조 구축

---

# ✨ 작업 내용 (What)

- 카카오 로그인 버튼 클릭 시 SDK 로그인 플로우 진입
- Kakao SDK 토큰(accessToken, idToken) 정상 획득 확인
- LoginActivity → ViewModel → Repository 구조로 카카오 토큰 전달하도록 구현
- ViewModel 내부에서 KakaoLoginRequest 모델 생성하도록 구조 정비
- observeKakaoLogin() 추가하여 카카오 로그인 결과 감지 처리
- 일반 로그인 로직과 카카오 로그인 로직 분리하여 유지보수성 향상
- 로딩 처리(loading LiveData) 일반 로그인/카카오 로그인 공통 적용 (UI 비활성화 포함)
- KakaoSdk.init() 및 Manifest 메타데이터 설정(MyApplication) 적용

---

# 🧩 변경 사항 (Changes)
📁 LoginActivity

- startKakaoLogin() 정리 → SDK 토큰만 받아서 ViewModel에 전달하는 구조로 단순화
- 불필요한 중복 함수(loginWithKakaoAccount, sendKakaoTokenToServer) 제거
- observeKakaoLogin() 추가하여 신규/기존 회원 분기 처리 가능하도록 기반 구성
- 버튼 비활성화/로딩 UI 반영

📁 AuthViewModel

- loginKakao(accessToken, idToken) 함수 신설
- KakaoLoginRequest 모델을 사용하도록 구조 수정
- 카카오 로그인 결과 LiveData (kakaoLoginState) 추가
- 기존 normal 로그인과 구조 통일 (Result<T> 기반)

📁 Repository

- loginKakao() API 연결 함수 추가 (POST /api/auth/login/kakao)
- RetrofitClient.authService 사용하도록 구성

📁 Manifest / Application

- KakaoSdk.init() 적용
- 카카오 login Redirect Activity 추가 (AuthCodeHandlerActivity + scheme 설정)

---

# 📸 스크린샷 (UI 변경 시 필수)

---

# 🧪 테스트 방법 (How to Test)
1. 앱 실행 → 로그인 화면 이동
2. 카카오 로그인 버튼 클릭
   - Logcat 에서 다음 로그 확인:
      - 0️⃣ 카카오 버튼 클릭됨
      - 1️⃣ startKakaoLogin() 호출됨
3. 카카오 SDK 로그인 창 정상 출력 확인
4. 토큰 획득 여부 Log 확인
5. ViewModel → observeKakaoLogin() 진입 여부 확인
6. 이후 BE에서 정상 응답이 올 경우:
   - 신규 회원 → “닉네임 설정 화면” 이동
   - 기존 회원 → MainActivity 이동

---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #00 (있을 경우)
